### PR TITLE
Get rid of separate input for port

### DIFF
--- a/src/js/container.es6.js
+++ b/src/js/container.es6.js
@@ -8,50 +8,49 @@ module.exports = React.createClass({
         return {connectedSockets: []};
     },
     componentWillMount () {
-        if ( !chrome.storage ) {
+        if (!chrome.storage) {
             var currentStorage = localStorage.getItem('connectedSockets');
-            if ( currentStorage ) {
-                var sockets = JSON.parse(currentStorage).map(function(uri){
-                    return io(uri, {reconnectionAttempts:10});
+            if (currentStorage) {
+                var sockets = JSON.parse(currentStorage).map(function (uri) {
+                    return io(uri, {reconnectionAttempts: 10});
                 });
                 this.setState({connectedSockets: sockets});
             }
         } else {
             const storageName = 'connectedSockets';
             chrome.storage.local.get(storageName, result => {
-                if ( result[storageName] ) {
-                    var sockets = result[storageName].map(function(uri){
-                     return io(uri, {reconnectionAttempts:10});
+                if (result[storageName]) {
+                    var sockets = result[storageName].map(function (uri) {
+                        return io(uri, {reconnectionAttempts: 10});
                     });
                     this.setState({connectedSockets: sockets});
                 }
             });
         }
     },
-    handleUrlSubmit (urlObject) {
-        const fullUrl = urlObject.url + ':' + urlObject.port;
+    handleUrlSubmit (url) {
         let sockets = this.state.connectedSockets;
         let alreadyExists = false;
         sockets.forEach(socket => {
-            if ( socket.io.uri === fullUrl ) {
+            if (socket.io.uri === url) {
                 alreadyExists = true;
             }
         });
-        if ( alreadyExists ) {
+        if (alreadyExists) {
             alert('Url already added.');
         } else {
-            if ( !chrome.storage ) {
-                localStorage.setItem(fullUrl, JSON.stringify({subbedEvents: []}));
+            if (!chrome.storage) {
+                localStorage.setItem(url, JSON.stringify({subbedEvents: []}));
             } else {
                 let storageObject = {};
-                storageObject[fullUrl] = {subbedEvents: []};
+                storageObject[url] = {subbedEvents: []};
                 chrome.storage.local.set(storageObject);
             }
-            let newSockets = sockets.concat([io(fullUrl, {reconnectionAttempts:10})]);
+            let newSockets = sockets.concat([io(url, {reconnectionAttempts: 10})]);
             this.setState({connectedSockets: newSockets}, () => {
-            // update localStorage
-                if ( !chrome.storage ) {
-                    localStorage.setItem('connectedSockets', JSON.stringify(this.state.connectedSockets.map(socket=>socket.io.uri)));
+                // update localStorage
+                if (!chrome.storage) {
+                    localStorage.setItem('connectedSockets', JSON.stringify(this.state.connectedSockets.map(socket => socket.io.uri)));
                 } else {
                     let storageObject = {};
                     storageObject.connectedSockets = this.state.connectedSockets.map(socket=>socket.io.uri);
@@ -61,7 +60,7 @@ module.exports = React.createClass({
         }
     },
     handleRemoveSocket (socket) {
-        if ( !chrome.storage ) {
+        if (!chrome.storage) {
             localStorage.removeItem(socket.io.uri);
             let currentStorage = JSON.parse(localStorage.getItem('connectedSockets'));
             currentStorage = currentStorage.filter(uri => uri !== socket.io.uri);
@@ -82,7 +81,7 @@ module.exports = React.createClass({
     },
     handleClearLocalStorage (event) {
         this.setState({connectedSockets: []}, () => {
-            if ( !chrome.storage ) {
+            if (!chrome.storage) {
                 localStorage.clear();
             } else {
                 chrome.storage.local.clear();
@@ -93,10 +92,12 @@ module.exports = React.createClass({
         // console.log('render Container');
         return (
             <div className="container">
-                <h1>Chrome socket.io extension<button onClick={this.handleClearLocalStorage} className="btn btn-default pull-right">Clear localStorage</button></h1>
+                <h1>Chrome socket.io extension
+                    <button onClick={this.handleClearLocalStorage} className="btn btn-default pull-right">Clear localStorage</button>
+                </h1>
                 <hr />
-                <UrlForm onUrlSubmit={this.handleUrlSubmit} />
-                <SocketList connectedSockets={this.state.connectedSockets} onRemoveSocket={this.handleRemoveSocket} />
+                <UrlForm onUrlSubmit={this.handleUrlSubmit}/>
+                <SocketList connectedSockets={this.state.connectedSockets} onRemoveSocket={this.handleRemoveSocket}/>
             </div>
         );
     }

--- a/src/js/urlForm.es6.js
+++ b/src/js/urlForm.es6.js
@@ -5,20 +5,16 @@ module.exports = React.createClass({
     handleSubmit (event) {
         event.preventDefault();
         let url = React.findDOMNode(this.refs.url).value.trim();
-        if ( !url.match('http://') ) {
-            url = `http://${url}`;
-        }
-        let port = React.findDOMNode(this.refs.port).value.trim();
-        if ( !url || !port ) {
+        if (!url) {
             return;
         }
-        this.props.onUrlSubmit({url, port});
+        if (!url.match('http://')) {
+            url = `http://${url}`;
+        }
+        this.props.onUrlSubmit(url);
         React.findDOMNode(this.refs.url).value = '';
-        React.findDOMNode(this.refs.port).value = '';
-        return;
     },
     render () {
-        // console.log('render UrlForm');
         return (
             <div className="urlForm">
                 <form className="form-inline" onSubmit={this.handleSubmit}>
@@ -26,9 +22,7 @@ module.exports = React.createClass({
                         <label for="urlInput">Url</label>
                         <input id="urlInput" type="text" placeholder="url" className="urlInput form-control" ref="url"></input>
                     </div>
-                    <span>:</span>
                     <div className="input-group">
-                        <input id="portInput" type="number" placeholder="port" className="portInput form-control" ref="port"></input>
                         <span className="input-group-btn">
                             <button className="btn btn-default" type="submit">Add</button>
                         </span>


### PR DESCRIPTION
Get rid of separate input for port to allow connecting to arbitrary URLs (i.e. with namespaces).

By having url:port constraint it was not possible to connect to socket.io namespace at example.com:8080/whatever.
